### PR TITLE
Single Version property for consistent versioning of binary and package

### DIFF
--- a/SnmpSharpNet/SnmpSharpNet.csproj
+++ b/SnmpSharpNet/SnmpSharpNet.csproj
@@ -5,8 +5,7 @@
     <Description>dotNet Simple Network Management Protocol Implementation</Description>
     <Copyright>Copyright © Milan Sinadinovic 2008 - 2014</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>0.9.6.0</AssemblyVersion>
-    <FileVersion>0.9.6.0</FileVersion>
+    <Version>0.9.6.0</Version>
   </PropertyGroup>
  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
    <NoWarn>1701;1702;1705;SA1629;SA1208;SA0001;SA1643;NU5104</NoWarn>


### PR DESCRIPTION
Generated nuget package has version 1.0.0 while assembly and project version are 0.9.6. I think the generated nuget package should also be 0.9.6. This can be done by adding a PackageVersion property to csproj but maybe better to revert AssemblyVersion and FileVersion back to default $(Version) and add a global Version attribute so that assembly and package version are all the same.